### PR TITLE
Use CircleCI for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+    - image: fpco/stack-build:lts-14.1
+    steps:
+    - checkout
+    - restore_cache:
+        name: Restore cached dependencies
+        keys:
+        - stack-cache
+    - run:
+        name: Update dependencies
+        command: stack --no-terminal setup
+    - run:
+        name: Run tests
+        command: stack --no-terminal test
+    - save_cache:
+        name: Cache dependencies
+        key: stack-cache
+        paths:
+        - /root/.stack
+        - .stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-13.27
+resolver: lts-14.1
 packages:
 - .


### PR DESCRIPTION
Use the `fpco/stack-build` container image for automated builds with CircleCI.